### PR TITLE
Fixes bug preventing hidden inputs from being typed in

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -66,9 +66,22 @@ export class ClientWrapper {
 
       case 'type':
         try {
+          await this.client.waitForSelector(selector, {visible: true, timeout: 5000});
           await this.client.type(selector, value);
         } catch (e) {
-          throw Error("Field may not be visible or can't be typed in.");
+          try {
+            await this.client.evaluate(
+              (selector, value) => {
+                document.querySelector(selector).focus();
+                document.querySelector(selector).value = value;
+                document.querySelector(selector).blur();
+                return true;
+              },
+              selector, value,
+            );
+          } catch (e) {
+            throw Error("Field may not be visible, or exist, or it can't be typed in.");
+          }
         }
         break;
     }

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -66,7 +66,7 @@ export class ClientWrapper {
 
       case 'type':
         try {
-          await this.client.waitForSelector(selector, {visible: true, timeout: 5000});
+          await this.client.waitForSelector(selector, { visible: true, timeout: 5000 });
           await this.client.type(selector, value);
         } catch (e) {
           try {

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -66,6 +66,7 @@ describe('ClientWrapper', () => {
     beforeEach(() => {
       pageStub = sinon.stub();
       pageStub.evaluate = sinon.stub();
+      pageStub.waitForSelector = sinon.stub();
       pageStub.select = sinon.stub();
       pageStub.type = sinon.stub();
     })
@@ -133,11 +134,29 @@ describe('ClientWrapper', () => {
       // Set up test instance.
       pageStub.evaluate.onCall(0).resolves('type');
       pageStub.type.resolves();
+      pageStub.waitForSelector.resolves();
       clientWrapperUnderTest = new ClientWrapper(pageStub, metadata);
 
       // Call the method and make assertions.
       await clientWrapperUnderTest.fillOutField(expectedSelector, expectedValue);
       expect(pageStub.type).to.have.been.calledWith(expectedSelector, expectedValue);
+      expect(pageStub.waitForSelector).to.have.been.calledWith(expectedSelector);
+    });
+
+    it('textInput:happyPathHiddenField', async () => {
+      const expectedSelector = 'input[name=Email]';
+      const expectedValue = 'atommy@example.com';
+
+      // Set up test instance.
+      pageStub.evaluate.onCall(0).resolves('type');
+      pageStub.type.resolves();
+      pageStub.waitForSelector.rejects();
+      pageStub.evaluate.onCall(1).resolves();
+      clientWrapperUnderTest = new ClientWrapper(pageStub, metadata);
+
+      // Call the method and make assertions.
+      await clientWrapperUnderTest.fillOutField(expectedSelector, expectedValue);
+      expect(pageStub.evaluate).to.have.been.calledWith(sinon.match.any, expectedSelector, expectedValue);
     });
 
     it('textInput:cannotTypeInField', () => {
@@ -147,6 +166,7 @@ describe('ClientWrapper', () => {
       // Set up test instance.
       pageStub.evaluate.onCall(0).resolves('type');
       pageStub.type.rejects();
+      pageStub.evaluate.onCall(1).rejects();
       clientWrapperUnderTest = new ClientWrapper(pageStub, metadata);
 
       // Call the method and make assertions.


### PR DESCRIPTION
Turns out Puppeteer does not throw an exception if you attempt to `page.type()` into a field that is not visible.  ...It just silently fails.

This PR resolves that by trying/catching to see if the element is visible.  If it is not, then it falls back to plain JS evaluated in the browser context.