### PR TITLE
Add a "check current page meta tag" step

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -173,6 +173,42 @@ export class ClientWrapper {
   }
 
   /**
+   * Retrieves the content of a meta tag with the given name.
+   *
+   * @param metaName - The name (or property) attribute of the meta tag whose
+   *   contents to return.
+   */
+  public async getMetaTagContent(metaName: string): Promise<String> {
+    // Special case for title.
+    if (metaName === 'title') {
+      return await this.client.evaluate(() => {
+        try {
+          return document.querySelector('title').innerText;
+        } catch (e) {
+          return null;
+        }
+      });
+    }
+
+    return await this.client.evaluate(
+      (name) => {
+        try {
+          return document.querySelector(`meta[name="${name}"]`)['content'];
+        } catch (e) {
+          // If the meta[name] didn't exist, try [property] (open graph support).
+          try {
+            return document.querySelector(`meta[property="${name}"]`)['content'];
+          } catch (e) {
+            // Always resolve to null so the step can handle it.
+            return null;
+          }
+        }
+      },
+      metaName,
+    );
+  }
+
+  /**
    * Returns a method name representing how to enter a value into an element,
    * found using the given DOM Query Selector.
    *

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -39,9 +39,14 @@ export abstract class BaseStep {
       const expectedField = new FieldDefinition();
       expectedField.setType(field.type);
       expectedField.setKey(field.field);
-      expectedField.setOptionality(field.optionality || FieldDefinition.Optionality.REQUIRED);
       expectedField.setDescription(field.description);
       stepDefinition.addExpectedFields(expectedField);
+
+      if (field.hasOwnProperty('optionality')) {
+        expectedField.setOptionality(field.optionality);
+      } else {
+        expectedField.setOptionality(FieldDefinition.Optionality.REQUIRED);
+      }
     });
 
     return stepDefinition;

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -12,6 +12,7 @@ export interface Field {
   field: string;
   type: FieldDefinition.Type;
   description: string;
+  optionality?: number;
 }
 
 export abstract class BaseStep {
@@ -38,7 +39,7 @@ export abstract class BaseStep {
       const expectedField = new FieldDefinition();
       expectedField.setType(field.type);
       expectedField.setKey(field.field);
-      expectedField.setOptionality(FieldDefinition.Optionality.REQUIRED);
+      expectedField.setOptionality(field.optionality || FieldDefinition.Optionality.REQUIRED);
       expectedField.setDescription(field.description);
       stepDefinition.addExpectedFields(expectedField);
     });

--- a/src/steps/check-current-page-meta-tag.ts
+++ b/src/steps/check-current-page-meta-tag.ts
@@ -26,7 +26,7 @@ export class CheckCurrentPageMetaTag extends BaseStep implements StepInterface {
     const stepData: any = step.getData().toJavaScript();
     const tag: string = stepData.metaName;
     const operator: string = stepData.operator;
-    const expectation: any = stepData.expectation;
+    const expectation: any = stepData.expectation || null;
 
     // Retrieve meta tag content.
     try {

--- a/src/steps/check-current-page-meta-tag.ts
+++ b/src/steps/check-current-page-meta-tag.ts
@@ -1,0 +1,95 @@
+import { BaseStep, Field, StepInterface } from '../core/base-step';
+import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto/cog_pb';
+
+export class CheckCurrentPageMetaTag extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check current page meta tag';
+  // tslint:disable-next-line:max-line-length
+  protected stepExpression: string = 'the (?<metaName>.+) meta tag on the current page should (?<operator>be|contain|not contain|not be longer than|exist) ?(?<expectation>.+)?';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected expectedFields: Field[] = [{
+    field: 'metaName',
+    type: FieldDefinition.Type.STRING,
+    description: 'Meta Tag name',
+  }, {
+    field: 'operator',
+    type: FieldDefinition.Type.STRING,
+    description: 'Check Logic (be, contain, not contain, not be longer than, exist)',
+  }, {
+    field: 'expectation',
+    type: FieldDefinition.Type.ANYSCALAR,
+    description: 'Expected Value',
+    optionality: FieldDefinition.Optionality.OPTIONAL,
+  }];
+
+  async executeStep(step: Step): Promise<RunStepResponse> {
+    const stepData: any = step.getData().toJavaScript();
+    const tag: string = stepData.metaName;
+    const operator: string = stepData.operator;
+    const expectation: any = stepData.expectation;
+
+    // Retrieve meta tag content.
+    try {
+      const actual = await this.client.getMetaTagContent(tag);
+      if (this.runComparison(operator, expectation, actual)) {
+        return this.pass('Meta tag check passed: %s should %s %s', [tag, operator, expectation]);
+      }
+
+      // Friendlier error messaging for the "exist" operator.
+      if (operator === 'exist') {
+        return this.fail('Meta tag check failed: %s should %s, but it was not found on the page', [
+          tag,
+          operator,
+        ]);
+      }
+
+      return this.fail('Meta tag check failed: %s should %s %s. It was actually %s', [
+        tag,
+        operator,
+        expectation,
+        actual,
+      ]);
+    } catch (e) {
+      return this.error('There was a problem checking the %s meta tag: %s', [tag, e.toString()]);
+    }
+  }
+
+/**
+ * Compare the expected and actual values using the appropriate operator.
+ */
+  protected runComparison(operator, expected, actual): boolean {
+    if (operator === 'exist') {
+      return actual !== null;
+    }
+
+    // If we're here, we should throw an error if no meta content was found.
+    // If we reason about a null value, the checks below are invalid.
+    if (actual === null) {
+      throw new Error("Can't evaluate meta tag that doesn't exist.");
+    }
+
+    if (operator === 'contain') {
+      return String(actual).toLowerCase().includes(String(expected).toLowerCase());
+    }
+
+    if (operator === 'not contain') {
+      return !String(actual).toLowerCase().includes(String(expected).toLowerCase());
+    }
+
+    if (operator === 'be') {
+      // tslint:disable-next-line:triple-equals
+      return expected == actual;
+    }
+
+    if (operator === 'not be longer than') {
+      return String(actual).length <= parseInt(expected, 10);
+    }
+
+    throw new Error(`Unknown check ${operator}. Should be one of: "${[
+      'contain', 'not contain', 'be', 'exist', 'not be longer than',
+    ].join('" "')}"`);
+  }
+
+}
+
+export { CheckCurrentPageMetaTag as Step };

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -263,8 +263,7 @@ describe('ClientWrapper', () => {
 
   });
 
-  describe('getCurrentPageDetails', () => {
-    let mainFrameStub: Record<string, any> = {};
+  describe('getCurrentPageInfo', () => {
 
     beforeEach(() => {
       pageStub = sinon.stub();
@@ -329,6 +328,50 @@ describe('ClientWrapper', () => {
       // Call the method and make assertions.
       const actual = await clientWrapperUnderTest.getCurrentPageInfo('status');
       expect(actual).to.be.string(expectedStatus);
+    });
+
+  });
+
+  describe('getMetaTagContent', () => {
+
+    beforeEach(() => {
+      pageStub = sinon.stub();
+      pageStub.evaluate = sinon.stub();
+    });
+
+    it('sadPath:pageEvalThrows', () => {
+      // Set up test instance.
+      pageStub.evaluate.throws();
+      clientWrapperUnderTest = new ClientWrapper(pageStub, metadata);
+
+      // Call the method and make assertions.
+      return expect(clientWrapperUnderTest.getMetaTagContent.bind(clientWrapperUnderTest, 'title'))
+        .to.throw;
+    });
+
+    it('happyPath:title', async () => {
+      const expectedTitle = 'Some Page Title';
+
+      // Set up test instance.
+      pageStub.evaluate.resolves(expectedTitle);
+      clientWrapperUnderTest = new ClientWrapper(pageStub, metadata);
+
+      // Call the method and make assertions.
+      const actual = await clientWrapperUnderTest.getMetaTagContent('title');
+      expect(actual).to.be.string(expectedTitle);
+    });
+
+    it('happyPath:otherTag', async () => {
+      const expectedOgDescription = 'Some Open Graph Description';
+
+      // Set up test instance.
+      pageStub.evaluate.resolves(expectedOgDescription);
+      clientWrapperUnderTest = new ClientWrapper(pageStub, metadata);
+
+      // Call the method and make assertions.
+      const actual = await clientWrapperUnderTest.getMetaTagContent('og:description');
+      expect(pageStub.evaluate).to.have.been.calledWith(sinon.match.any, 'og:description');
+      expect(actual).to.be.string(expectedOgDescription);
     });
 
   });


### PR DESCRIPTION
Providing a step to check the `content` attributes of `<meta>` HTML tags will unlock a number of base-level and advanced SEO test scenarios.

An example scenario:

```yml
scenario: Moz minimal social tags test
description: |
  Ensures that the given page follows Moz's recommendations for minimal social
  tags for a given page. See https://moz.com/blog/meta-data-templates-123

tokens:
  test:
    url: https://github.com/run-crank/cog-web
  expected:
    phrase: A generic web browser Cog for Crank

steps:
- step: When I navigate to {{test.url}}
- step: Then the title meta tag on the current page should not be longer than 70 characters
- step: And the title meta tag on the current page should contain {{expected.phrase}}
- step: And the viewport meta tag on the current page should exist (null)
- step: And the description meta tag on the current page should not be longer than 160 characters
- step: And the description meta tag on the current page should contain {{expected.phrase}}
- step: And the twitter:card meta tag on the current page should contain summary
- step: And the og:title meta tag on the current page should exist (null)
- step: And the og:type meta tag on the current page should exist (null)
- step: And the og:url meta tag on the current page should contain {{test.url}}
- step: And the og:image meta tag on the current page should exist (null)
- step: And the og:description meta tag on the current page should contain {{expected.phrase}}

```