### PR TITLE
Scroll behavior changes

### DIFF
--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -4,16 +4,32 @@ import { Promise as Bluebird } from 'bluebird';
 export class BasicInteractionAware {
   public client: Page;
 
-  public async scrollThrough(depth: number) {
+  public async scrollTo(depth: number) {
     try {
+      // Perform scroll.
       await this.client.evaluate(
         (percent) => {
           const floatValue = percent / 100;
-          window.scrollBy(0, document.body.scrollHeight * floatValue);
+          window.scroll({
+            left: 0,
+            top: document.body.scrollHeight * floatValue,
+            behavior: 'smooth',
+          });
         },
-        depth);
+        depth,
+      );
+
+      // Wait until scroll completes.
+      await this.client.waitFor(
+        (percent) => {
+          const floatValue = percent / 100;
+          return window.scrollY + window.innerHeight >= document.body.scrollHeight * floatValue;
+        },
+        {},
+        depth,
+      );
     } catch (e) {
-      throw Error(`Unable to scroll through ${depth} percent depth: ${e}`);
+      throw Error(`Unable to scroll to ${depth} percent depth: ${e}`);
     }
   }
 

--- a/src/steps/scroll-to.ts
+++ b/src/steps/scroll-to.ts
@@ -1,11 +1,11 @@
 import { BaseStep, Field, StepInterface } from '../core/base-step';
 import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto/cog_pb';
 
-export class ScrollThrough extends BaseStep implements StepInterface {
+export class ScrollTo extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Scroll through a percentage of a web page';
+  protected stepName: string = 'Scroll to a percentage depth of a web page';
   // tslint:disable-next-line:max-line-length
-  protected stepExpression: string = 'scroll through (?<depth>\\d+)% of the page';
+  protected stepExpression: string = 'scroll to (?<depth>\\d+)% of the page';
   protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
   protected expectedFields: Field[] = [{
     field: 'depth',
@@ -18,10 +18,10 @@ export class ScrollThrough extends BaseStep implements StepInterface {
     const depth: number = stepData.depth;
 
     try {
-      await this.client.scrollThrough(depth);
-      return this.pass('Successfully scrolled through %s%% of the page', [depth]);
+      await this.client.scrollTo(depth);
+      return this.pass('Successfully scrolled to %s%% of the page', [depth]);
     } catch (e) {
-      return this.error('There was a problem scrolling through %s%% of the page', [
+      return this.error('There was a problem scrolling to %s%% of the page', [
         depth,
         e.toString(),
       ]);
@@ -30,4 +30,4 @@ export class ScrollThrough extends BaseStep implements StepInterface {
 
 }
 
-export { ScrollThrough as Step };
+export { ScrollTo as Step };

--- a/test/steps/scroll-to.ts
+++ b/test/steps/scroll-to.ts
@@ -5,11 +5,11 @@ import * as sinonChai from 'sinon-chai';
 import 'mocha';
 
 import { Step as ProtoStep, StepDefinition, FieldDefinition, RunStepResponse } from '../../src/proto/cog_pb';
-import { Step } from '../../src/steps/scroll-through';
+import { Step } from '../../src/steps/scroll-to';
 
 chai.use(sinonChai);
 
-describe('ScrollThroughPage', () => {
+describe('ScrollToPage', () => {
   const expect = chai.expect;
   let protoStep: ProtoStep;
   let stepUnderTest: Step;
@@ -18,7 +18,7 @@ describe('ScrollThroughPage', () => {
   beforeEach(() => {
     // Set up test stubs.
     clientWrapperStub = sinon.stub();
-    clientWrapperStub.scrollThrough = sinon.stub();
+    clientWrapperStub.scrollTo = sinon.stub();
     stepUnderTest = new Step(clientWrapperStub);
     protoStep = new ProtoStep();
   });
@@ -26,9 +26,9 @@ describe('ScrollThroughPage', () => {
   describe('Metadata', () => {
     it('should return expected step metadata', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
-      expect(stepDef.getStepId()).to.equal('ScrollThrough');
-      expect(stepDef.getName()).to.equal('Scroll through a percentage of a web page');
-      expect(stepDef.getExpression()).to.equal('scroll through (?<depth>\\d+)% of the page');
+      expect(stepDef.getStepId()).to.equal('ScrollTo');
+      expect(stepDef.getName()).to.equal('Scroll to a percentage depth of a web page');
+      expect(stepDef.getExpression()).to.equal('scroll to (?<depth>\\d+)% of the page');
       expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
     });
 
@@ -45,10 +45,10 @@ describe('ScrollThroughPage', () => {
   });
 
   describe('ExecuteStep', () => {
-    describe('Scrolled through', () => {
+    describe('Scrolled to', () => {
       const expectedDepth = 50;
       beforeEach(() => {
-        clientWrapperStub.scrollThrough.returns(Promise.resolve());
+        clientWrapperStub.scrollTo.returns(Promise.resolve());
         protoStep.setData(
           Struct.fromJavaScript(
             {
@@ -58,9 +58,9 @@ describe('ScrollThroughPage', () => {
         );
       });
 
-      it('should call scroll through with expectedArgs', async () => {
+      it('should call scroll to with expectedArgs', async () => {
         await stepUnderTest.executeStep(protoStep);
-        expect(clientWrapperStub.scrollThrough).to.have.been.calledWith(expectedDepth);
+        expect(clientWrapperStub.scrollTo).to.have.been.calledWith(expectedDepth);
       });
 
       it('should respond with pass', async () => {
@@ -69,10 +69,10 @@ describe('ScrollThroughPage', () => {
       });
     });
 
-    describe('Scroll through did not occur', () => {
+    describe('Scroll to did not occur', () => {
       const expectedDepth = 50;
       beforeEach(() => {
-        clientWrapperStub.scrollThrough.throws();
+        clientWrapperStub.scrollTo.throws();
         protoStep.setData(
             Struct.fromJavaScript(
               {


### PR DESCRIPTION
- Renames `Scroll Through` to `Scroll To` to allow for scrolling up/down a page, as needed [#22]
- Adds a deterministic wait on the scroll step [#21]

Note: under normal circumstances, this would be a backwards compatibility break (changing an existing step expression), but since these steps haven't made it out in a point release, we're okay to update.