### PR TITLE
Fix Marketo form regression

### DIFF
--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -98,7 +98,9 @@ export class BasicInteractionAware {
     // });
 
     // Make ourselves identifiable and set a more realistic desktop browser size.
-    await this.client.setUserAgent(ua.replace(' Chrome', ' AutomatonHeadlessChrome'));
+    // Note: We do not use "Headless" in our UA name, because Marketo's Cloudfront
+    // configuration blocks requests from UAs matching that pattern.
+    await this.client.setUserAgent(ua.replace(' Chrome', ' AutomatonChrome'));
     await this.client.setViewport({ width: 1280, height: 960 });
     const response = await this.client.goto(url, { waitUntil: 'networkidle0' });
 

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -40,7 +40,7 @@ describe('ClientWrapper', () => {
     it('happyPath', async () => {
       const expectedUrl = 'https://example.com';
       const originalUserAgent = 'Mozilla/a.b Chrome/x.y.z';
-      const expectedUserAgent = 'Mozilla/a.b AutomatonHeadlessChrome/x.y.z';
+      const expectedUserAgent = 'Mozilla/a.b AutomatonChrome/x.y.z';
       const expectedLastResponse = 'This would be a puppeteer response object';
 
       // Set up test instance.


### PR DESCRIPTION
- Any UA containing "Headless" is blocked by Marketo's Cloudfront configuration.