### PR TITLE
Initial Implementation of Check Network Requests

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -1,5 +1,5 @@
 import * as grpc from 'grpc';
-import { BasicInteractionAware, DomAware, ResponseAware, MarketoAware, GoogleAnalyticsAware, LighthouseAware, LinkedInAwareMixin } from './mixins';
+import { BasicInteractionAware, DomAware, ResponseAware, MarketoAware, GoogleAnalyticsAware, LighthouseAware, LinkedInAwareMixin, NetworkAware } from './mixins';
 import { Field } from '../core/base-step';
 import { Page, Request } from 'puppeteer';
 import * as Lighthouse from 'lighthouse';
@@ -97,9 +97,9 @@ class ClientWrapper {
 
 }
 
-interface ClientWrapper extends BasicInteractionAware, DomAware, ResponseAware, MarketoAware, GoogleAnalyticsAware, LighthouseAware, LinkedInAwareMixin {}
+interface ClientWrapper extends BasicInteractionAware, DomAware, ResponseAware, MarketoAware, GoogleAnalyticsAware, LighthouseAware, LinkedInAwareMixin, NetworkAware {}
 
-applyMixins(ClientWrapper, [BasicInteractionAware, DomAware, ResponseAware, MarketoAware, GoogleAnalyticsAware, LighthouseAware, LinkedInAwareMixin]);
+applyMixins(ClientWrapper, [BasicInteractionAware, DomAware, ResponseAware, MarketoAware, GoogleAnalyticsAware, LighthouseAware, LinkedInAwareMixin, NetworkAware]);
 
 function applyMixins(derivedCtor: any, baseCtors: any[]) {
   baseCtors.forEach((baseCtor) => {

--- a/src/client/mixins/index.ts
+++ b/src/client/mixins/index.ts
@@ -5,3 +5,4 @@ export * from './marketo';
 export * from './google-analytics';
 export * from './lighthouse';
 export * from './linked-in';
+export * from './network';

--- a/src/client/mixins/network.ts
+++ b/src/client/mixins/network.ts
@@ -1,0 +1,61 @@
+
+import { URL } from 'url';
+import * as querystring from 'querystring';
+
+const OTHER_REQUEST_METHODS = ['POST', 'PATCH', 'PUT'];
+const VALID_CONTENT_TYPES = ['application/json', 'application/json;charset=UTF-8', 'application/x-www-form-urlencoded'];
+
+export class NetworkAware {
+
+  async getNetworkRequests(baseUrl: string, pathContains: string) {
+    await (this as any).waitForNetworkIdle(10000, false);
+    const requests = await (this as any).getFinishedRequests();
+
+    const matchedRequests = requests.filter(r => r.url.startsWith(baseUrl) && (new URL(r.url).pathname.includes(pathContains) && pathContains));
+    return matchedRequests;
+  }
+
+  evaluateRequests(requests, expectedParams) {
+    const matching = [];
+
+    requests.forEach((request) => {
+      //// The Iterator logic can be factored out
+      if (request.method == 'GET') {
+        const url = new URL(request.url);
+
+        let matched = true;
+
+        url.searchParams.forEach((value, key) => {
+          if (expectedParams.hasOwnProperty(key) && matched) {
+            matched = expectedParams[key] == value;
+          }
+        });
+
+        if (matched) {
+          matching.push(request);
+        }
+
+      } else if (OTHER_REQUEST_METHODS.includes(request.method)) {
+        const requestHasValidContentType = VALID_CONTENT_TYPES.filter(f => f.includes(request.rawRequest._headers['content-type'])).length > 0;
+        if (requestHasValidContentType) {
+          let matched = true;
+
+          let postData;
+          try { postData = JSON.parse(request.postData); } catch (e) { postData = querystring.parse(request.postData); }
+
+          for (const [key, value] of Object.entries(postData)) {
+            if (expectedParams.hasOwnProperty(key) && matched) {
+              matched = expectedParams[key] == value;
+            }
+          }
+
+          if (matched) {
+            matching.push(request);
+          }
+        }
+      }
+    });
+
+    return matching;
+  }
+}

--- a/src/client/mixins/network.ts
+++ b/src/client/mixins/network.ts
@@ -37,10 +37,10 @@ export class NetworkAware {
         if (requestHasValidContentType) {
           try { actualParams = JSON.parse(request.postData); } catch (e) { actualParams = querystring.parse(request.postData); }
         } else {
-          throw new Error(`The request\'s content type ${contentType} is not supported`);
+          throw new Error(`Unknown Content Type: ${contentType}`);
         }
       } else {
-        throw new Error(`The request method ${request.method} is not supported`);
+        throw new Error(`Unknown Request Method: ${request.method}`);
       }
 
       let matched = true;

--- a/src/steps/check-network-request.ts
+++ b/src/steps/check-network-request.ts
@@ -1,0 +1,115 @@
+import { BaseStep, Field, StepInterface } from '../core/base-step';
+import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto/cog_pb';
+
+import { URL } from 'url';
+import * as querystring from 'querystring';
+
+const OTHER_REQUEST_METHODS = ['POST', 'PATCH', 'PUT'];
+const VALID_CONTENT_TYPES = ['application/json', 'application/json;charset=UTF-8', 'application/x-www-form-urlencoded'];
+
+export class CheckNetworkRequestStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check for a specific network request';
+  // tslint:disable-next-line:max-line-length
+  protected stepExpression: string = 'there should be (?<reqCount>\\d+) matching network requests? for (?<baseUrl>.+)';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected expectedFields: Field[] = [{
+    field: 'reqCount',
+    type: FieldDefinition.Type.NUMERIC,
+    description: '# of Requests',
+  }, {
+    field: 'baseUrl',
+    type: FieldDefinition.Type.URL,
+    description: 'Base URL Is',
+  }, {
+    field: 'pathContains',
+    type: FieldDefinition.Type.STRING,
+    description: 'Path Contains',
+  }, {
+    field: 'withParameters',
+    type: FieldDefinition.Type.MAP,
+    description: 'Parameters Include',
+  }];
+
+  async executeStep(step: Step): Promise<RunStepResponse> {
+    const stepData: any = step.getData().toJavaScript();
+    const reqCount = stepData.reqCount;
+    const baseUrl = stepData.baseUrl;
+    const pathContains = stepData.pathContains || '';
+    const withParameters = stepData.withParameters;
+
+    try {
+      //// This will ensure that NavigateTo was called
+      await this.client.getCurrentPageInfo('url');
+
+      await this.client.waitForNetworkIdle(10000, false);
+      const requests = await this.client.getFinishedRequests();
+
+      const matchingRequests = requests.filter(r => r.url.startsWith(baseUrl) && r.url.includes(pathContains)); //// string.includes(empty) is always true
+      const evaluatedRequests = this.evaluateRequests(matchingRequests, withParameters);
+
+      if (evaluatedRequests.length !== reqCount) {
+        return this.fail('Expected %d matching network request(s), but %d were found:\n\n%s', [
+          reqCount,
+          evaluatedRequests.length,
+          evaluatedRequests.map(r => `${r.url}\n`),
+        ]);
+      }
+
+      return this.pass('%d network requests found, as expected', [
+        evaluatedRequests.length,
+      ]);
+    } catch (e) {
+      return this.error('There was a problem checking network request: %s', [
+        e.toString(),
+      ]);
+    }
+  }
+
+  evaluateRequests(requests, expectedParams) {
+    const matching = [];
+
+    requests.forEach((request) => {
+      //// The Iterator logic can be factored out
+      if (request.method == 'GET') {
+        const url = new URL(request.url);
+
+        let matched = true;
+
+        url.searchParams.forEach((value, key) => {
+          if (expectedParams.hasOwnProperty(key) && matched) {
+            matched = expectedParams[key] == value;
+          }
+        });
+
+        if (matched) {
+          matching.push(request);
+        }
+
+      } else if (OTHER_REQUEST_METHODS.includes(request.method)) {
+        const requestHasValidContentType = VALID_CONTENT_TYPES.filter(f => f.includes(request.rawRequest._headers['content-type'])).length > 0;
+        if (requestHasValidContentType) {
+          let matched = true;
+
+          let postData;
+          try { postData = JSON.parse(request.postData); } catch (e) { postData = querystring.parse(request.postData); }
+
+          for (const [key, value] of Object.entries(postData)) {
+            if (expectedParams.hasOwnProperty(key) && matched) {
+              matched = expectedParams[key] == value;
+            }
+          }
+
+          if (matched) {
+            matching.push(request);
+          }
+        }
+      }
+    });
+
+    return matching;
+  }
+
+}
+
+export { CheckNetworkRequestStep as Step };

--- a/src/steps/check-network-request.ts
+++ b/src/steps/check-network-request.ts
@@ -38,8 +38,6 @@ export class CheckNetworkRequestStep extends BaseStep implements StepInterface {
       //// This will ensure that NavigateTo was called
       await this.client.getCurrentPageInfo('url');
 
-      await this.client.waitForNetworkIdle(10000, false);
-
       const matchingRequests = await this.client.getNetworkRequests(baseUrl, pathContains);
       const evaluatedRequests = this.client.evaluateRequests(matchingRequests, withParameters);
 

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -786,7 +786,7 @@ describe('ClientWrapper', () => {
         expect(result.length).to.equal(0);
       });
 
-      it('should throw error when a not supported content type is evaluated', () => {
+      it('should throw error when an unknown content type is evaluated', () => {
         const expectedParams = {
           wrongProperty: 'Wrong Property',
           wrongValue: 'Wrong Value',
@@ -800,6 +800,28 @@ describe('ClientWrapper', () => {
             rawRequest: {
               _headers: {
                 'content-type': 'invalid/content-type',
+              },
+            },
+          },
+        ];
+
+        expect(clientWrapperUnderTest.evaluateRequests.bind(null, requests, expectedParams)).to.throw();
+      });
+
+      it('should throw error when an unknown request method is evaluated', () => {
+        const expectedParams = {
+          wrongProperty: 'Wrong Property',
+          wrongValue: 'Wrong Value',
+        };
+
+        const requests = [
+          {
+            method: 'UNKNOWN',
+            url: 'http://thisisjust.atomatest.com/api/users',
+            postData: JSON.stringify({ name: 'Atomatommy' }),
+            rawRequest: {
+              _headers: {
+                'content-type': 'application/json',
               },
             },
           },

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -693,4 +693,120 @@ describe('ClientWrapper', () => {
 
     });
   });
+
+  describe('Check Network Requests', () => {
+    describe('GET requests', () => {
+      beforeEach(() => {
+        clientWrapperUnderTest = new ClientWrapper(pageStub, new Metadata());
+      });
+
+      it('should return at least 1 request that matched with expected query params', () => {
+        const requests = [
+          {
+            method: 'GET',
+            url: 'http://thisisjust.atomatest.com?id=1&query=test',
+          },
+        ];
+
+        const expectedParams = {
+          id: '1',
+          query: 'test',
+        };
+
+        const result = clientWrapperUnderTest.evaluateRequests(requests, expectedParams);
+        expect(result.length).to.be.greaterThan(0);
+      });
+
+      it('should return no request(s) when query params are not matched', () => {
+        const requests = [
+          {
+            method: 'GET',
+            url: 'http://thisisjust.atomatest.com?id=1&query=test',
+          },
+        ];
+
+        const expectedParams = {
+          id: '1000000',
+          color: '000000',
+        };
+
+        const result = clientWrapperUnderTest.evaluateRequests(requests, expectedParams);
+        expect(result.length).to.equal(0);
+      });
+    });
+
+    describe('POST requests', () => {
+      beforeEach(() => {
+        clientWrapperUnderTest = new ClientWrapper(pageStub, new Metadata());
+      });
+
+      it('should return at least 1 request that matched with expected query params', () => {
+        const expectedParams = {
+          name: 'Atomatommy',
+          country: 'US',
+        };
+
+        const requests = [
+          {
+            method: 'POST',
+            url: 'http://thisisjust.atomatest.com/api/users',
+            postData: JSON.stringify(expectedParams),
+            rawRequest: {
+              _headers: {
+                'content-type': 'application/json',
+              },
+            },
+          },
+        ];
+
+        const result = clientWrapperUnderTest.evaluateRequests(requests, expectedParams);
+        expect(result.length).to.be.greaterThan(0);
+      });
+
+      it('should return no request(s) when postData are not matched', () => {
+        const expectedParams = {
+          wrongProperty: 'Wrong Property',
+          wrongValue: 'Wrong Value',
+        };
+
+        const requests = [
+          {
+            method: 'POST',
+            url: 'http://thisisjust.atomatest.com/api/users',
+            postData: JSON.stringify({ name: 'Atomatommy' }),
+            rawRequest: {
+              _headers: {
+                'content-type': 'application/json',
+              },
+            },
+          },
+        ];
+
+        const result = clientWrapperUnderTest.evaluateRequests(requests, expectedParams);
+        expect(result.length).to.equal(0);
+      });
+
+      it('should throw error when a not supported content type is evaluated', () => {
+        const expectedParams = {
+          wrongProperty: 'Wrong Property',
+          wrongValue: 'Wrong Value',
+        };
+
+        const requests = [
+          {
+            method: 'POST',
+            url: 'http://thisisjust.atomatest.com/api/users',
+            postData: JSON.stringify({ name: 'Atomatommy' }),
+            rawRequest: {
+              _headers: {
+                'content-type': 'invalid/content-type',
+              },
+            },
+          },
+        ];
+
+        expect(clientWrapperUnderTest.evaluateRequests.bind(null, requests, expectedParams)).to.throw();
+      });
+    });
+  });
 });

--- a/test/scenarios/Network Requests/Network Request Check - GET.crank.yml
+++ b/test/scenarios/Network Requests/Network Request Check - GET.crank.yml
@@ -1,0 +1,12 @@
+scenario: Checks Network Requests for https://www.blackboard.com/
+description: |
+  This checks GET requests and url params
+
+steps:
+- step: When I navigate to https://www.blackboard.com/
+- step: Then there should be 1 matching network request for https://s2376.t.eloqua.com
+  data:
+    pathContains: /visitor/v200/svrGP.aspx
+    withParameters:
+      siteid: 2376
+      optin: disabled

--- a/test/scenarios/Network Requests/Network Request Check - POST.crank.yml
+++ b/test/scenarios/Network Requests/Network Request Check - POST.crank.yml
@@ -1,0 +1,18 @@
+scenario: Checks Network Requests for https://www.onupkeep.com/
+description: |
+  This checks both application/json and application/x-www-form-urlencoded content types for POST
+
+steps:
+- step: When I navigate to https://www.onupkeep.com/
+# JSON Payload Check
+- step: Then there should be 1 matching network request for https://app.coview.com
+  data:
+    pathContains: /api/client-info/launcher
+    withParameters:
+      projectKey: Av-EzYN98DI
+# Form Payload Check
+- step: And there should be 1 matching network request for https://api-iam.intercom.io
+  data:
+    pathContains: /messenger/web/ping
+    withParameters:
+      app_id: c8ise6cp

--- a/test/steps/check-network-request.ts
+++ b/test/steps/check-network-request.ts
@@ -1,0 +1,112 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, FieldDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/check-network-request';
+
+chai.use(sinonChai);
+
+describe('CheckNetworkRequest', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    // Set up test stubs.
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.getCurrentPageInfo = sinon.stub();
+    clientWrapperStub.getNetworkRequests = sinon.stub();
+    clientWrapperStub.evaluateRequests = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+    protoStep = new ProtoStep();
+  });
+
+  describe('Metadata', () => {
+    it('should return expected step metadata', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      expect(stepDef.getStepId()).to.equal('CheckNetworkRequestStep');
+      expect(stepDef.getName()).to.equal('Check for a specific network request');
+      expect(stepDef.getExpression()).to.equal('there should be (?<reqCount>\\d+) matching network requests? for (?<baseUrl>.+)');
+      expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
+    });
+
+    it('should return expected step fields', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
+        return field.toObject();
+      });
+
+      const reqCount: any = fields.filter(f => f.key === 'reqCount')[0];
+      expect(reqCount.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(reqCount.type).to.equal(FieldDefinition.Type.NUMERIC);
+
+      const baseUrl: any = fields.filter(f => f.key === 'baseUrl')[0];
+      expect(baseUrl.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(baseUrl.type).to.equal(FieldDefinition.Type.URL);
+
+      const pathContains: any = fields.filter(f => f.key === 'pathContains')[0];
+      expect(pathContains.optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+      expect(pathContains.type).to.equal(FieldDefinition.Type.STRING);
+
+      const withParameters: any = fields.filter(f => f.key === 'withParameters')[0];
+      expect(withParameters.optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+      expect(withParameters.type).to.equal(FieldDefinition.Type.MAP);
+    });
+  });
+
+  describe('ExecuteStep', () => {
+    describe('Navigate To not called', () => {
+      beforeEach(() => {
+        clientWrapperStub.getCurrentPageInfo.throws();
+        protoStep.setData(Struct.fromJavaScript({
+          reqCount: 1,
+          baseUrl: 'http://thisisjust.atomatest.com',
+        }));
+      });
+
+      it('should respond with error', async () => {
+        const response = await stepUnderTest.executeStep(protoStep);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+      });
+    });
+
+    describe('Matched requests count is not equal to Expected requests count', () => {
+      beforeEach(() => {
+        clientWrapperStub.getCurrentPageInfo.returns(Promise.resolve('http://thisisjust.atomatest.com'));
+        clientWrapperStub.getNetworkRequests.returns(Promise.resolve([]));
+        clientWrapperStub.evaluateRequests.returns([{}]);
+        protoStep.setData(Struct.fromJavaScript({
+          reqCount: 10,
+          baseUrl: 'http://thisisjust.atomatest.com',
+        }));
+      });
+
+      it('should respond with fail', async () => {
+        const response = await stepUnderTest.executeStep(protoStep);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+      });
+    });
+
+    describe('Matched requests count is equal to Expected requests count', () => {
+      beforeEach(() => {
+        clientWrapperStub.getCurrentPageInfo.returns(Promise.resolve('http://thisisjust.atomatest.com'));
+        clientWrapperStub.getNetworkRequests.returns(Promise.resolve([]));
+        // tslint:disable-next-line:prefer-array-literal
+        clientWrapperStub.evaluateRequests.returns(new Array(10));
+        protoStep.setData(Struct.fromJavaScript({
+          reqCount: 10,
+          baseUrl: 'http://thisisjust.atomatest.com',
+        }));
+      });
+
+      it('should respond with fail', async () => {
+        const response = await stepUnderTest.executeStep(protoStep);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# For #65 
 - Caters for all scenarios provided in the issue
 - The `evaluateRequests` can still be refactored and potentially transferred to a `mixin` 
 - Scenario files attached