### PR TITLE
Handle Puppeteer Cluster Unrecoverable State

### DIFF
--- a/src/core/grpc-server.ts
+++ b/src/core/grpc-server.ts
@@ -50,5 +50,13 @@ instantiateCluster().then((cluster) => {
   });
 });
 
+// Special handler for when Puppeteer Cluster is in an unrecoverable state.
+// @see https://github.com/thomasdondorf/puppeteer-cluster/issues/207
+process.on('unhandledRejection', (up) => {
+  if (up.toString().includes('Unable to restart chrome')) {
+    throw up;
+  }
+});
+
 // Export server for testing.
 export default server;


### PR DESCRIPTION
In case of Puppeteer Cluster being unable to restart Chrome, throw an explicit error, killing the process.  This will allow the container to be restarted and for clients to retry.