### PR TITLE
Few fixes for Network Request step

### DIFF
--- a/src/client/mixins/network.ts
+++ b/src/client/mixins/network.ts
@@ -13,9 +13,11 @@ export class NetworkAware {
     const requests = await (this as any).getFinishedRequests();
 
     let matchedRequests = requests.filter(r => r.url.startsWith(baseUrl));
+
     if (pathContains) {
       matchedRequests = matchedRequests.filter(r => (new URL(r.url).pathname.includes(pathContains) && pathContains));
     }
+
     return matchedRequests;
   }
 

--- a/src/steps/check-network-request.ts
+++ b/src/steps/check-network-request.ts
@@ -45,7 +45,7 @@ export class CheckNetworkRequestStep extends BaseStep implements StepInterface {
         return this.fail('Expected %d matching network request(s), but %d were found:\n\n%s', [
           reqCount,
           evaluatedRequests.length,
-          matchingRequests.map(r => `${r.url}\n\n`),
+          evaluatedRequests.map(r => `${r.url}\n\n`).join(''),
         ]);
       }
 

--- a/test/scenarios/Network Requests/Network Request Check - POST.crank.yml
+++ b/test/scenarios/Network Requests/Network Request Check - POST.crank.yml
@@ -1,18 +1,18 @@
-scenario: Checks Network Requests for https://www.onupkeep.com/
+scenario: Checks Network Requests for https://www.marketo.com/
 description: |
   This checks both application/json and application/x-www-form-urlencoded content types for POST
 
 steps:
-- step: When I navigate to https://www.onupkeep.com/
+- step: When I navigate to https://www.marketo.com/
 # JSON Payload Check
-- step: Then there should be 1 matching network request for https://app.coview.com
-  data:
-    pathContains: /api/client-info/launcher
-    withParameters:
-      projectKey: Av-EzYN98DI
+- step: Then there should be 1 matching network request for https://dpm.demdex.net
+  # data:
+  #   pathContains: /api/client-info/launcher
+  #   withParameters:
+  #     projectKey: Av-EzYN98DI
 # Form Payload Check
-- step: And there should be 1 matching network request for https://api-iam.intercom.io
-  data:
-    pathContains: /messenger/web/ping
-    withParameters:
-      app_id: c8ise6cp
+# - step: And there should be 1 matching network request for https://api-iam.intercom.io
+#   data:
+#     pathContains: /messenger/web/ping
+#     withParameters:
+#       app_id: c8ise6cp

--- a/test/scenarios/Network Requests/Network Request Check - POST.crank.yml
+++ b/test/scenarios/Network Requests/Network Request Check - POST.crank.yml
@@ -1,18 +1,18 @@
-scenario: Checks Network Requests for https://www.marketo.com/
+scenario: Checks Network Requests for https://www.onupkeep.com/
 description: |
   This checks both application/json and application/x-www-form-urlencoded content types for POST
 
 steps:
-- step: When I navigate to https://www.marketo.com/
+- step: When I navigate to https://www.onupkeep.com/
 # JSON Payload Check
-- step: Then there should be 1 matching network request for https://dpm.demdex.net
-  # data:
-  #   pathContains: /api/client-info/launcher
-  #   withParameters:
-  #     projectKey: Av-EzYN98DI
+- step: Then there should be 1 matching network request for https://app.coview.com
+  data:
+    pathContains: /api/client-info/launcher
+    withParameters:
+      projectKey: Av-EzYN98DI
 # Form Payload Check
-# - step: And there should be 1 matching network request for https://api-iam.intercom.io
-#   data:
-#     pathContains: /messenger/web/ping
-#     withParameters:
-#       app_id: c8ise6cp
+- step: And there should be 1 matching network request for https://api-iam.intercom.io
+  data:
+    pathContains: /messenger/web/ping
+    withParameters:
+      app_id: c8ise6cp


### PR DESCRIPTION
 Fixes for #94 
 - Fixed an issue where the displayed network requests on error has trailing `comma ,` 
 - Fixed an issue where the count of the found url does not match on the displayed count on the message