### PR TITLE
Changed filtering of requests for GA steps

### DIFF
--- a/src/steps/check-google-analytics-page-view.ts
+++ b/src/steps/check-google-analytics-page-view.ts
@@ -35,17 +35,18 @@ export class CheckGoogleAnalyticsPageView extends BaseStep implements StepInterf
   async executeStep(step: Step): Promise<RunStepResponse> {
     const stepData: any = step.getData().toJavaScript();
     const id: any = stepData.id;
-    const expectedParams: any = stepData.withParameters || {};
+    const expectedParams: any = stepData.withParameters;
+    const requiredParams = {
+      t: 'pageview',
+      tid: id,
+    };
     let result;
     try {
       await this.client.waitForNetworkIdle(10000, false);
-      const requests = await this.client.getFinishedRequests();
-      const urls = requests.filter(r => r.method == 'GET'
-                                        && r.url.includes('https://www.google-analytics.com')
-                                        && r.url.includes('/collect')
-                                        && r.url.includes('t=pageview')).map(r => r.url);
-      const filteredRequest = urls.filter(url => url.includes(`tid=${id}`));
+      const requests = await this.client.getNetworkRequests('https://www.google-analytics.com', '/collect');
+      const filteredRequest = this.client.evaluateRequests(requests, requiredParams).map(r => r.url);
       result = filteredRequest;
+
       let records = [];
       let filteredRequestsWithParams = [];
       if (!isNullOrUndefined(expectedParams)) {

--- a/test/steps/check-google-analytics-event.ts
+++ b/test/steps/check-google-analytics-event.ts
@@ -18,8 +18,9 @@ describe('CheckGoogleAnalyticsEvent', () => {
   beforeEach(() => {
     // Set up test stubs.
     clientWrapperStub = sinon.stub();
-    clientWrapperStub.getFinishedRequests = sinon.stub();
     clientWrapperStub.waitForNetworkIdle = sinon.stub();
+    clientWrapperStub.getNetworkRequests = sinon.stub();
+    clientWrapperStub.evaluateRequests = sinon.stub();
     stepUnderTest = new Step(clientWrapperStub);
     protoStep = new ProtoStep();
   });
@@ -82,7 +83,8 @@ describe('CheckGoogleAnalyticsEvent', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -109,7 +111,8 @@ describe('CheckGoogleAnalyticsEvent', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -135,7 +138,8 @@ describe('CheckGoogleAnalyticsEvent', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -165,7 +169,8 @@ describe('CheckGoogleAnalyticsEvent', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -199,7 +204,8 @@ describe('CheckGoogleAnalyticsEvent', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -220,7 +226,7 @@ describe('CheckGoogleAnalyticsEvent', () => {
     };
 
     // Stub a response that matches expectations.
-    clientWrapperStub.getFinishedRequests.throws(error);
+    clientWrapperStub.getNetworkRequests.throws(error);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));

--- a/test/steps/check-google-analytics-page-view.ts
+++ b/test/steps/check-google-analytics-page-view.ts
@@ -18,8 +18,8 @@ describe('CheckGoogleAnalyticsPageView', () => {
   beforeEach(() => {
     // Set up test stubs.
     clientWrapperStub = sinon.stub();
-    clientWrapperStub.getFinishedRequests = sinon.stub();
     clientWrapperStub.waitForNetworkIdle = sinon.stub();
+    clientWrapperStub.getNetworkRequests = sinon.stub();
     clientWrapperStub.evaluateRequests = sinon.stub();
     stepUnderTest = new Step(clientWrapperStub);
     protoStep = new ProtoStep();
@@ -69,8 +69,8 @@ describe('CheckGoogleAnalyticsPageView', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
-    clientWrapperStub.evaluateRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -92,7 +92,8 @@ describe('CheckGoogleAnalyticsPageView', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -122,7 +123,8 @@ describe('CheckGoogleAnalyticsPageView', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -148,7 +150,8 @@ describe('CheckGoogleAnalyticsPageView', () => {
 
     // Stub a response that matches expectations.
     clientWrapperStub.waitForNetworkIdle.resolves();
-    clientWrapperStub.getFinishedRequests.resolves(expectedResult);
+    clientWrapperStub.getNetworkRequests.resolves(expectedResult);
+    clientWrapperStub.evaluateRequests.returns(expectedResult);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(dataInput));
@@ -162,7 +165,8 @@ describe('CheckGoogleAnalyticsPageView', () => {
     const expectedData = { id: 'someId' };
 
     // Stub a response that matches expectations.
-    clientWrapperStub.getFinishedRequests.throws(error);
+    clientWrapperStub.waitForNetworkIdle.resolves();
+    clientWrapperStub.getNetworkRequests.throws(error);
 
     // Set step data corresponding to expectations
     protoStep.setData(Struct.fromJavaScript(expectedData));


### PR DESCRIPTION
- address bug where test pass when Id for example `UA-75228722-` instead of `UA-75228722-5` because filter uses includes