### PR TITLE
Allow Puppeteer Cluster configurations to be modified via env vars

### DIFF
--- a/src/core/grpc-server.ts
+++ b/src/core/grpc-server.ts
@@ -24,10 +24,10 @@ if (process.env.USE_SSL) {
 async function instantiateCluster(): Promise<Cluster> {
   return await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_CONTEXT,
-    maxConcurrency: 4,
-    retryLimit: 3,
-    retryDelay: 3000,
-    timeout: 120000,
+    maxConcurrency: process.env.hasOwnProperty('CLUSTER_MAX_CONCURRENCY') ? Number(process.env.CLUSTER_MAX_CONCURRENCY) : 4,
+    retryLimit: process.env.hasOwnProperty('CLUSTER_RETRY_LIMIT') ? Number(process.env.CLUSTER_RETRY_LIMIT) : 3,
+    retryDelay: process.env.hasOwnProperty('CLUSTER_RETRY_DELAY_MS') ? Number(process.env.CLUSTER_RETRY_DELAY_MS) : 3000,
+    timeout: process.env.hasOwnProperty('CLUSTER_TIMEOUT_MS') ? Number(process.env.CLUSTER_TIMEOUT_MS) : 120000,
     puppeteerOptions: {
       headless: false,
       args: process.env.IN_DOCKER ? [


### PR DESCRIPTION
- `CLUSTER_MAX_CONCURRENCY` max number of tasks that can be performed simultaneously before the Cog queues step requests internally.
- `CLUSTER_RETRY_LIMIT` max number of retry attempts, should a task throw an exception
- `CLUSTER_RETRY_DELAY_MS` number of milliseconds between retry attempts
- `CLUSTER_TIMEOUT_MS` max number of milliseconds before a single task / request stream is considered to have timed out