### PR TITLE
Added NavigateAndSubmitForm step and tests

### DIFF
--- a/src/steps/navigate-and-submit-form.ts
+++ b/src/steps/navigate-and-submit-form.ts
@@ -1,0 +1,43 @@
+import { BaseStep, Field, StepInterface } from '../core/base-step';
+import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto/cog_pb';
+
+export class NavigateAndSubmitForm extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Navigate and submit form';
+  // tslint:disable-next-line:max-line-length
+  protected stepExpression: string = 'navigate to (?<webPageUrl>.+) and find a form';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.ACTION;
+  protected expectedFields: Field[] = [{
+    field: 'webPageUrl',
+    type: FieldDefinition.Type.URL,
+    description: 'Page URL',
+  }];
+
+  async executeStep(step: Step): Promise<RunStepResponse> {
+    const stepData: any = step.getData().toJavaScript();
+    const url: string = stepData.webPageUrl;
+
+    // Navigate to URL.
+    try {
+      await this.client.navigateToUrl(url);
+      const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });
+      const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/jpeg', screenshot);
+      return this.pass('Successfully navigated to %s', [url], [binaryRecord]);
+    } catch (e) {
+      const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });
+      const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/jpeg', screenshot);
+      return this.error(
+        'There was a problem navigating to %s: %s',
+        [
+          url,
+          e.toString(),
+        ],
+        [
+          binaryRecord,
+        ]);
+    }
+  }
+
+}
+
+export { NavigateAndSubmitForm as Step };

--- a/test/steps/navigate-and-submit-form.ts
+++ b/test/steps/navigate-and-submit-form.ts
@@ -1,0 +1,71 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, FieldDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/navigate-and-submit-form';
+
+chai.use(sinonChai);
+
+describe('NavigateAndSubmitForm', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    // Set up test stubs.
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.navigateToUrl = sinon.stub();
+    clientWrapperStub.client = sinon.stub();
+    clientWrapperStub.client.screenshot = sinon.stub();
+    clientWrapperStub.client.screenshot.returns('anyBinary');
+    stepUnderTest = new Step(clientWrapperStub);
+    protoStep = new ProtoStep();
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('NavigateAndSubmitForm');
+    expect(stepDef.getName()).to.equal('Navigate and submit form');
+    expect(stepDef.getExpression()).to.equal('navigate to (?<webPageUrl>.+) and find a form');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.ACTION);
+  });
+
+  it('should return expected step fields', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
+      return field.toObject();
+    });
+
+    // Web Page URL field
+    const pageUrl: any = fields.filter(f => f.key === 'webPageUrl')[0];
+    expect(pageUrl.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+    expect(pageUrl.type).to.equal(FieldDefinition.Type.URL);
+  });
+
+  it('should pass when puppeteer successfully navigates to page', async () => {
+    // Stub a response that matches expectations.
+    clientWrapperStub.navigateToUrl.resolves();
+
+    // Set step data corresponding to expectations
+    protoStep.setData(Struct.fromJavaScript({webPageUrl: 'https://mayaswell.exist'}));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with error if puppeteer is unable to navigate', async () => {
+    // Stub a navigation that rejects.
+    clientWrapperStub.navigateToUrl.rejects();
+
+    // Set step data corresponding to expectations
+    protoStep.setData(Struct.fromJavaScript({webPageUrl: 'https://doesnot.exist'}));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+});


### PR DESCRIPTION
Created a new step and tests for Navigate And Submit Form.  This is in response to [this task](https://automatoninc.visualstudio.com/Automatest/_sprints/backlog/Atomatest%20Team/Automatest/Sprint%2080%20-%20Onshore?workitem=3479) . 

Essentially, this step is just to make a new pill in the stack moxie app.  NavigateAndSubmitForm is just a copy of the NavigateToPage step with slightly different metadata.  The front end will take the NavigateAndSubmitForm step and initiate the automation/shine to find a form on the page.

Andrei, if you know of a better way to create a new pill please let me know.  I tried to find a way to add a pill on the MonoRepo front end, but I could not come up with a good solution.