### PR TITLE
Added CheckAllNetworkRequestsStep for use with Pixel Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This Cog does not require any authentication details.
 | **Navigate to a webpage**<br>(`NavigateToPage`) | `navigate to (?<webPageUrl>.+)` | - `webPageUrl`: Page URL |
 | **Scroll to a percentage depth of a web page**<br>(`ScrollTo`) | `scroll to (?<depth>\d+)% of the page` | - `depth`: Percent Depth |
 | **Submit a form by clicking a button**<br>(`SubmitFormByClickingButton`) | `submit the form by clicking (?<domQuerySelector>.+)` | - `domQuerySelector`: Button's DOM Query Selector |
+| **Check all network requests**<br>(`CheckAllNetworkRequestsStep`) | `there should be network requests from the page` | - `none` |
 <!-- stepDetailsEnd -->
 
 ## Development and Contributing

--- a/src/steps/check-all-network-requests.ts
+++ b/src/steps/check-all-network-requests.ts
@@ -1,0 +1,80 @@
+import { BaseStep, Field, StepInterface } from '../core/base-step';
+import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto/cog_pb';
+
+export class CheckAllNetworkRequestsStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check for all network requests';
+  // tslint:disable-next-line:max-line-length
+  protected stepExpression: string = 'there should be network requests from the page';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected expectedFields: Field[] = [];
+
+  async executeStep(step: Step): Promise<RunStepResponse> {
+    const sources = {};
+
+    try {
+      //// This will ensure that NavigateTo was called
+      await this.client.getCurrentPageInfo('url');
+
+      const networkRequests = await this.client.getFinishedRequests();
+      // Get all network requests fired by the webpage
+      networkRequests.forEach((request) => {
+        if (request.url) {
+          const removeHttp = request.url.split('://');
+          // Collect sources and count by baseUrl
+          const baseUrl = removeHttp[1] ? `${removeHttp[0]}://${removeHttp[1].split('/')[0]}` : removeHttp[0];
+          if (!Object.keys(sources).includes(baseUrl)) {
+            sources[baseUrl] = { url: baseUrl, count: 1 };
+          } else {
+            sources[baseUrl].count += 1;
+          }
+        }
+      });
+
+      const urls = Object.keys(sources);
+
+      const records = [];
+      if (urls.length === 0) {
+        return this.fail(
+          'Expected network request(s), but %d were found:\n\n', [
+            urls.length,
+          ],
+          records);
+      }
+      if (urls.length > 0) {
+        records.push(this.createTable(sources));
+      }
+      return this.pass(
+        '%d sources found, as expected',
+        [
+          urls.length,
+        ],
+        records);
+    } catch (e) {
+      return this.error('There was a problem checking network request: %s', [
+        e.toString(),
+      ]);
+    }
+  }
+
+  private createTable(sources) {
+    const headers = {};
+    const rows = [];
+    headers['fires'] = 'fires';
+    headers['url'] = 'url';
+
+    Object.keys(sources).forEach((source) => {
+      const url = sources[source].url;
+      const count = sources[source].count;
+      rows.push({ url, fires: count });
+    });
+
+    const headerKeys = Object.keys(rows[0] || {});
+    headerKeys.forEach((key: string) => {
+      headers[key] = key;
+    });
+    return this.table('pixels', 'Network Sources', headers, rows);
+  }
+}
+
+export { CheckAllNetworkRequestsStep as Step };

--- a/test/steps/check-all-network-requests.ts
+++ b/test/steps/check-all-network-requests.ts
@@ -1,0 +1,87 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, FieldDefinition, RunStepResponse } from '../../src/proto/cog_pb';
+import { Step } from '../../src/steps/check-all-network-requests';
+
+chai.use(sinonChai);
+
+describe('CheckAllNetworkRequests', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    // Set up test stubs.
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.getCurrentPageInfo = sinon.stub();
+    clientWrapperStub.getFinishedRequests = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+    protoStep = new ProtoStep();
+  });
+
+  describe('Metadata', () => {
+    it('should return expected step metadata', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      expect(stepDef.getStepId()).to.equal('CheckAllNetworkRequestsStep');
+      expect(stepDef.getName()).to.equal('Check for all network requests');
+      expect(stepDef.getExpression()).to.equal('there should be network requests from the page');
+      expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
+    });
+
+    it('should return expected step fields', () => {
+      const stepDef: StepDefinition = stepUnderTest.getDefinition();
+      const fields: any[] = stepDef.getExpectedFieldsList().map((field: FieldDefinition) => {
+        return field.toObject();
+      });
+
+      expect(fields.length).to.equal(0);
+    });
+  });
+
+  describe('ExecuteStep', () => {
+    describe('Navigate To not called', () => {
+      beforeEach(() => {
+        clientWrapperStub.getCurrentPageInfo.throws();
+        protoStep.setData(Struct.fromJavaScript({
+          reqCount: 1,
+          baseUrl: 'http://thisisjust.atomatest.com',
+        }));
+      });
+
+      it('should respond with error', async () => {
+        const response = await stepUnderTest.executeStep(protoStep);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+      });
+    });
+
+    describe('Zero requests should result in an error', () => {
+      beforeEach(() => {
+        clientWrapperStub.getCurrentPageInfo.returns(Promise.resolve('http://thisisjust.atomatest.com'));
+        clientWrapperStub.getFinishedRequests.returns(Promise.resolve([]));
+      });
+
+      it('should respond with fail', async () => {
+        const response = await stepUnderTest.executeStep(protoStep);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+      });
+    });
+
+    describe('One or more requests should result in pass', () => {
+      beforeEach(() => {
+        clientWrapperStub.getCurrentPageInfo.returns(Promise.resolve('http://thisisjust.atomatest.com'));
+        clientWrapperStub.getFinishedRequests.returns(Promise.resolve([{ url: 'https://www.someurl.com' }]));
+        // tslint:disable-next-line:prefer-array-literal
+      });
+
+      it('should respond with pass', async () => {
+        const response = await stepUnderTest.executeStep(protoStep);
+        expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Added a new step that will find all network requests (sources) from a website and return a table of the baseUrl of each source and how many times they were fired. This step will only work after a NavigateToPage step. 

This step was made specifically for use in the Stack Moxie Pixel Starter scenario.