### PR TITLE
NavigateToPage return fail on error 404

### DIFF
--- a/src/steps/navigate-to-page.ts
+++ b/src/steps/navigate-to-page.ts
@@ -22,6 +22,10 @@ export class NavigateToPage extends BaseStep implements StepInterface {
       await this.client.navigateToUrl(url);
       const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });
       const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/jpeg', screenshot);
+      const status = await this.client.client['___lastResponse']['status']();
+      if (status === 404) {
+        return this.fail('%s returned an Error: 404 Not Found', [url], [binaryRecord]);
+      }
       return this.pass('Successfully navigated to %s', [url], [binaryRecord]);
     } catch (e) {
       const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });

--- a/test/steps/navigate-to-page.ts
+++ b/test/steps/navigate-to-page.ts
@@ -22,6 +22,9 @@ describe('NavigateToPage', () => {
     clientWrapperStub.client = sinon.stub();
     clientWrapperStub.client.screenshot = sinon.stub();
     clientWrapperStub.client.screenshot.returns('anyBinary');
+    clientWrapperStub.client['___lastResponse'] = sinon.stub();
+    clientWrapperStub.client['___lastResponse']['status'] = sinon.stub();
+    clientWrapperStub.client['___lastResponse']['status'].returns(200);
     stepUnderTest = new Step(clientWrapperStub);
     protoStep = new ProtoStep();
   });
@@ -54,7 +57,21 @@ describe('NavigateToPage', () => {
     protoStep.setData(Struct.fromJavaScript({webPageUrl: 'https://mayaswell.exist'}));
 
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    console.log(response.getOutcome());
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should fail when the page returns a status 404', async () => {
+    // Stub a response that matches expectations.
+    clientWrapperStub.navigateToUrl.resolves();
+    clientWrapperStub.client['___lastResponse']['status'].returns(404);
+
+    // Set step data corresponding to expectations
+    protoStep.setData(Struct.fromJavaScript({webPageUrl: 'https://mayaswell.exist'}));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    console.log(response.getOutcome());
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
   });
 
   it('should respond with error if puppeteer is unable to navigate', async () => {


### PR DESCRIPTION
Navigate to a webpage will now fail when the server responds with an error 404.