### PR TITLE
Redirects after form submit or button click

### DIFF
--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -106,6 +106,13 @@ export class BasicInteractionAware {
     } catch (e) {
       throw Error('Element may not be visible or clickable');
     }
+    const response = await this.client['___currentFrame'].waitForNavigation({ timeout: 15000 });
+    if (response) {
+      // Stash this response on the client. Adding the data to the client is the
+      // only way to persist this response object between steps.
+      // @see this.getCurrentPageInfo()
+      this.client['___lastResponse'] = response;
+    }
   }
 
   /**
@@ -259,9 +266,6 @@ export class BasicInteractionAware {
               // only way to persist this response object between steps.
               // @see this.getCurrentPageInfo()
               this.client['___lastResponse'] = response;
-
-              // Set the current active frame by:
-              this.client['___currentFrame'] = this.client.mainFrame();
             })
             .then(res)
             .catch(e => rej(Error('Page did not redirect')));

--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -147,7 +147,7 @@ export class BasicInteractionAware {
 
     // Stash this response on the client. Adding the data to the client is the
     // only way to persist this response object between steps.
-    // @see this.getCurrentPageDetails()
+    // @see this.getCurrentPageInfo()
     this.client['___lastResponse'] = response;
 
     // Set the current active frame by:
@@ -251,6 +251,19 @@ export class BasicInteractionAware {
       [
         new Promise((res, rej) => {
           this.client['___currentFrame'].waitForNavigation({ timeout: 15000 })
+            .then((response) => {
+              if (!response) {
+                throw new Error;
+              }
+              // Stash this response on the client. Adding the data to the client is the
+              // only way to persist this response object between steps.
+              // @see this.getCurrentPageInfo()
+              this.client['___lastResponse'] = response;
+
+              // Set the current active frame by:
+              this.client['___currentFrame'] = this.client.mainFrame();
+              // console.log(this.client['___currentFrame']);
+            })
             .then(res)
             .catch(e => rej(Error('Page did not redirect')));
         }),

--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -262,7 +262,6 @@ export class BasicInteractionAware {
 
               // Set the current active frame by:
               this.client['___currentFrame'] = this.client.mainFrame();
-              // console.log(this.client['___currentFrame']);
             })
             .then(res)
             .catch(e => rej(Error('Page did not redirect')));

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -623,6 +623,7 @@ describe('ClientWrapper', () => {
       pageStub['___currentFrame'] = sinon.stub();
       pageStub['___currentFrame'].evaluate = sinon.stub();
       pageStub['___currentFrame'].waitFor = sinon.stub();
+      pageStub['___currentFrame'].waitForNavigation = sinon.stub();
 
       // Stub out event emitter.
       pageStub.listenerCount = sinon.stub();
@@ -637,6 +638,7 @@ describe('ClientWrapper', () => {
 
       beforeEach(() => {
         pageStub['___currentFrame'].waitFor.resolves();
+        pageStub['___currentFrame'].waitFor.resolves('httpResponse');
         pageStub['___currentFrame'].evaluate.resolves();
       });
 

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -368,6 +368,7 @@ describe('ClientWrapper', () => {
       pageStub.waitForNavigation = sinon.stub();
       pageStub.waitForFunction = sinon.stub();
       pageStub.waitFor = sinon.stub();
+      pageStub.mainFrame = sinon.stub();
 
       pageStub.listenerCount = sinon.stub();
       pageStub.listenerCount.onFirstCall().returns(0);
@@ -389,13 +390,15 @@ describe('ClientWrapper', () => {
 
     it('happyPath:submitFormAndPageRedirects', async () => {
       const expectedButtonSelector = 'button[type=submit]';
+      const response = 'httpResponse';
 
       // Set up test instance.
-      pageStub['___currentFrame'].waitForNavigation.resolves();
-      pageStub['___currentFrame'].waitForFunction.resolves();
+      pageStub['___currentFrame'].waitForNavigation.resolves(response);
+      pageStub['___currentFrame'].waitForFunction.resolves(true);
       pageStub['___currentFrame'].waitFor.rejects();
       pageStub['___currentFrame'].listeners.resolves([]);
       pageStub['___currentFrame'].addListener.resolves();
+      pageStub.mainFrame.returns('mainFrame');
       clientWrapperUnderTest = new ClientWrapper(pageStub, metadata);
 
       // Call the method and make assertions.


### PR DESCRIPTION
If the browser is redirected after clicking a button or submitting a form, this update will set `this.client['___lastResponse']` to the response from the redirect. This will allow a user to run "Check Current Page Info" after a form submit or button click to check info about the redirected page (usually a "Thank You" page). 