### PR TITLE
postData fix for evaluateRequests

### DIFF
--- a/src/client/mixins/network.ts
+++ b/src/client/mixins/network.ts
@@ -4,7 +4,7 @@ import { URL } from 'url';
 import * as querystring from 'querystring';
 
 const OTHER_REQUEST_METHODS = ['POST', 'PATCH', 'PUT'];
-const SUPPORTED_CONTENT_TYPES = ['application/json', 'application/json;charset=UTF-8', 'application/x-www-form-urlencoded', 'text/plain'];
+const SUPPORTED_CONTENT_TYPES = ['application/json', 'application/json;charset=UTF-8', 'application/x-www-form-urlencoded', 'text/plain', 'none'];
 
 export class NetworkAware {
 
@@ -40,9 +40,17 @@ export class NetworkAware {
       if (request.method === 'GET') {
         actualParams = this.convertParamsToObject(new URL(request.url).searchParams);
       } else if (OTHER_REQUEST_METHODS.includes(request.method)) {
-        const contentType = request.rawRequest._headers['content-type'];
-        const requestHasValidContentType = SUPPORTED_CONTENT_TYPES.filter((f) => f.includes(contentType) || contentType.includes(f)).length > 0;
-        const postData = request.postData ? JSON.parse(request.postData) : this.convertParamsToObject(new URL(request.url).searchParams);
+        const contentType = request.rawRequest._headers['content-type'] || 'none';
+        const requestHasValidContentType = SUPPORTED_CONTENT_TYPES.filter((f) => f.includes(contentType) ||  contentType.includes(f)).length > 0;
+        const isJsonString = (string) => {
+          try {
+            JSON.parse(string);
+          } catch (e) {
+            return false;
+          }
+          return true;
+        };
+        const postData = request.postData && isJsonString(request.postData) ? JSON.parse(request.postData) : this.convertParamsToObject(new URL(request.url).searchParams);
         if (requestHasValidContentType) {
           try {
             actualParams = postData;

--- a/src/client/mixins/network.ts
+++ b/src/client/mixins/network.ts
@@ -41,7 +41,7 @@ export class NetworkAware {
         actualParams = this.convertParamsToObject(new URL(request.url).searchParams);
       } else if (OTHER_REQUEST_METHODS.includes(request.method)) {
         const contentType = request.rawRequest._headers['content-type'] || 'none';
-        const requestHasValidContentType = SUPPORTED_CONTENT_TYPES.filter((f) => f.includes(contentType) ||  contentType.includes(f)).length > 0;
+        const requestHasValidContentType = SUPPORTED_CONTENT_TYPES.filter((f) => f.includes(contentType) || contentType.includes(f)).length > 0;
         const isJsonString = (string) => {
           try {
             JSON.parse(string);


### PR DESCRIPTION
- Fixed an issue where the method would sometimes try to parse a string that was not JSON.
- Accommodated for network requests that have no content-type header