### PR TITLE
NavigateToPage throttle option

### DIFF
--- a/src/client/mixins/basic-interaction.ts
+++ b/src/client/mixins/basic-interaction.ts
@@ -147,8 +147,9 @@ export class BasicInteractionAware {
    * throws an error. Otherwise, it will resolve on successful navigation.
    *
    * @param {String} url - The URL of the page to nagivate to.
+   * @param {Boolean} throttle - Will throttle down the browser speed. Defaults to false.
    */
-  public async navigateToUrl(url: string) {
+  public async navigateToUrl(url: string, throttle: boolean = false) {
     console.log('>>>>> inside navigateToUrl basic interaction');
     console.timeLog('time');
     this.client['__networkRequests'] = null;
@@ -156,16 +157,18 @@ export class BasicInteractionAware {
     const ua = await browser.userAgent();
     console.log('>>>>> checkpoint 1: finished setting up browser');
     console.timeLog('time');
-    // Connect to Chrome DevTools and set throttling. Consider making this its
-    // own step in the future.
-    // @see https://fdalvi.github.io/blog/2018-02-05-puppeteer-network-throttle/
-    // const devTools = await this.client.target().createCDPSession();
-    // await devTools.send('Network.emulateNetworkConditions', {
-    //   'offline': false,
-    //   'downloadThroughput': 1.5 * 1024 * 1024 / 8,
-    //   'uploadThroughput': 750 * 1024 / 8,
-    //   'latency': 40
-    // });
+    if (throttle) {
+      // Connect to Chrome DevTools and set throttling. Consider making this its
+      // own step in the future.
+      // @see https://fdalvi.github.io/blog/2018-02-05-puppeteer-network-throttle/
+      const devTools = await this.client.target().createCDPSession();
+      await devTools.send('Network.emulateNetworkConditions', {
+        offline: false,
+        downloadThroughput: 1.5 * 1024 * 1024 / 8,
+        uploadThroughput: 750 * 1024 / 8,
+        latency: 40,
+      });
+    }
 
     // Make ourselves identifiable and set a more realistic desktop browser size.
     // Note: We do not use "Headless" in our UA name, because Marketo's Cloudfront

--- a/src/steps/navigate-to-page.ts
+++ b/src/steps/navigate-to-page.ts
@@ -11,17 +11,23 @@ export class NavigateToPage extends BaseStep implements StepInterface {
     field: 'webPageUrl',
     type: FieldDefinition.Type.URL,
     description: 'Page URL',
+  }, {
+    field: 'throttle',
+    type: FieldDefinition.Type.BOOLEAN,
+    description: 'Throttle Browser',
+    optionality: FieldDefinition.Optionality.OPTIONAL,
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {
     const stepData: any = step.getData().toJavaScript();
     const url: string = stepData.webPageUrl;
+    const throttle: boolean = stepData.throttle || false;
 
     // Navigate to URL.
     try {
       console.time('time');
       console.log('>>>>> STARTED TIMER FOR NAVIGATE-TO-PAGE STEP');
-      await this.client.navigateToUrl(url);
+      await this.client.navigateToUrl(url, throttle);
       const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });
       const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/jpeg', screenshot);
       console.log('>>>>> checkpoint 6: finished taking screenshot and making binary record');

--- a/test/steps/navigate-to-page.ts
+++ b/test/steps/navigate-to-page.ts
@@ -47,6 +47,11 @@ describe('NavigateToPage', () => {
     const pageUrl: any = fields.filter(f => f.key === 'webPageUrl')[0];
     expect(pageUrl.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
     expect(pageUrl.type).to.equal(FieldDefinition.Type.URL);
+
+    // Throttle Browser field
+    const throttle: any = fields.filter(f => f.key === 'throttle')[0];
+    expect(throttle.optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
+    expect(throttle.type).to.equal(FieldDefinition.Type.BOOLEAN);
   });
 
   it('should pass when puppeteer successfully navigates to page', async () => {


### PR DESCRIPTION
Gives NavigateToPage an optional throttle field. The field will default to false. If set to true, the throttle will slow down the browser speed before it navigates to the page.