### PR TITLE
Navigate Step Enhancements

### DIFF
--- a/src/steps/marketo-navigate-and-query-form.ts
+++ b/src/steps/marketo-navigate-and-query-form.ts
@@ -16,13 +16,22 @@ export class MarketoNavigateAndQueryForm extends BaseStep implements StepInterfa
   async executeStep(step: Step): Promise<RunStepResponse> {
     const stepData: any = step.getData().toJavaScript();
     const url: string = stepData.webPageUrl;
+    const throttle: boolean = stepData.throttle || false;
+    const maxInflightRequests: number = stepData.maxInflightRequests || 0;
+    const networkIdleTime: number = stepData.networkIdleTime || 500;
 
     // Navigate to URL.
     try {
-      await this.client.navigateToUrl(url);
+      console.time('time');
+      console.log('>>>>> STARTED TIMER FOR MARKETOO-NAVIGATE-AND-QUERY-FORM STEP');
+      await this.client.navigateToUrl(url, throttle, maxInflightRequests, networkIdleTime);
       const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });
       const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/jpeg', screenshot);
+      console.log('>>>>> checkpoint 6: finished taking screenshot and making binary record');
+      console.timeLog('time');
       const status = await this.client.client['___lastResponse']['status']();
+      console.log('>>>>> checkpoint 7: finished getting status, ending timer');
+      console.timeEnd('time');
       if (status === 404) {
         return this.fail('%s returned an Error: 404 Not Found', [url], [binaryRecord]);
       }

--- a/src/steps/navigate-and-submit-form.ts
+++ b/src/steps/navigate-and-submit-form.ts
@@ -16,12 +16,15 @@ export class NavigateAndSubmitForm extends BaseStep implements StepInterface {
   async executeStep(step: Step): Promise<RunStepResponse> {
     const stepData: any = step.getData().toJavaScript();
     const url: string = stepData.webPageUrl;
+    const throttle: boolean = stepData.throttle || false;
+    const maxInflightRequests: number = stepData.maxInflightRequests || 0;
+    const networkIdleTime: number = stepData.networkIdleTime || 500;
 
     // Navigate to URL.
     try {
       console.time('time');
       console.log('>>>>> STARTED TIMER FOR NAVIGATE-AND-SUBMIT-FORM STEP');
-      await this.client.navigateToUrl(url);
+      await this.client.navigateToUrl(url, throttle, maxInflightRequests, networkIdleTime);
       const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });
       const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/jpeg', screenshot);
       console.log('>>>>> checkpoint 6: finished taking screenshot and making binary record');

--- a/src/steps/navigate-to-page.ts
+++ b/src/steps/navigate-to-page.ts
@@ -11,23 +11,20 @@ export class NavigateToPage extends BaseStep implements StepInterface {
     field: 'webPageUrl',
     type: FieldDefinition.Type.URL,
     description: 'Page URL',
-  }, {
-    field: 'throttle',
-    type: FieldDefinition.Type.BOOLEAN,
-    description: 'Throttle Browser',
-    optionality: FieldDefinition.Optionality.OPTIONAL,
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {
     const stepData: any = step.getData().toJavaScript();
     const url: string = stepData.webPageUrl;
     const throttle: boolean = stepData.throttle || false;
+    const maxInflightRequests: number = stepData.maxInflightRequests || 0;
+    const networkIdleTime: number = stepData.networkIdleTime || 500;
 
     // Navigate to URL.
     try {
       console.time('time');
       console.log('>>>>> STARTED TIMER FOR NAVIGATE-TO-PAGE STEP');
-      await this.client.navigateToUrl(url, throttle);
+      await this.client.navigateToUrl(url, throttle, maxInflightRequests, networkIdleTime);
       const screenshot = await this.client.client.screenshot({ type: 'jpeg', encoding: 'binary', quality: 60 });
       const binaryRecord = this.binary('screenshot', 'Screenshot', 'image/jpeg', screenshot);
       console.log('>>>>> checkpoint 6: finished taking screenshot and making binary record');

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -107,6 +107,8 @@ describe('ClientWrapper', () => {
       pageStub.goto = sinon.stub();
       pageStub.mainFrame = sinon.stub();
       pageStub.addListener = sinon.stub();
+      pageStub.on = sinon.stub();
+      pageStub.removeListener = sinon.stub();
 
       // Stub out event emitter.
       pageStub.listenerCount = sinon.stub();
@@ -131,7 +133,7 @@ describe('ClientWrapper', () => {
       expect(pageStub.setUserAgent).to.have.been.calledWith(expectedUserAgent);
       expect(pageStub.setViewport).to.have.been.calledWith(sinon.match.has('width', 1280));
       expect(pageStub.setViewport).to.have.been.calledWith(sinon.match.has('height', 960));
-      expect(pageStub.goto).to.have.been.calledWith(expectedUrl, { waitUntil: 'networkidle0', timeout: 90000 });
+      expect(pageStub.goto).to.have.been.calledWith(expectedUrl);
       expect(pageStub.___lastResponse).to.be.string(expectedLastResponse);
     });
 
@@ -145,7 +147,7 @@ describe('ClientWrapper', () => {
       clientWrapperUnderTest = new ClientWrapper(pageStub, metadata, idMap, blobContainerClient);
 
       // Call the method and make assertions.
-      return expect(clientWrapperUnderTest.navigateToUrl(expectedUrl)).to.be.rejected;
+      expect(clientWrapperUnderTest.navigateToUrl(expectedUrl)).to.be.rejected;
     });
 
   });

--- a/test/steps/navigate-to-page.ts
+++ b/test/steps/navigate-to-page.ts
@@ -47,11 +47,6 @@ describe('NavigateToPage', () => {
     const pageUrl: any = fields.filter(f => f.key === 'webPageUrl')[0];
     expect(pageUrl.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
     expect(pageUrl.type).to.equal(FieldDefinition.Type.URL);
-
-    // Throttle Browser field
-    const throttle: any = fields.filter(f => f.key === 'throttle')[0];
-    expect(throttle.optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
-    expect(throttle.type).to.equal(FieldDefinition.Type.BOOLEAN);
   });
 
   it('should pass when puppeteer successfully navigates to page', async () => {


### PR DESCRIPTION
The navigate steps will now have the following optional fields:
1. throttle - Throttles down the speed of the web browser
2. maxInflightRequests - Max number of network connections in flight before navigation is considered done. Defaults to 0.
3. networkIdleTime - Time in ms that the network must be idle before navigation is considered done. Defaults to 500.