### PR TITLE
Remove units from ScrollTo expected field

### DIFF
--- a/src/steps/scroll-to.ts
+++ b/src/steps/scroll-to.ts
@@ -13,11 +13,6 @@ export class ScrollTo extends BaseStep implements StepInterface {
     field: 'depth',
     type: FieldDefinition.Type.NUMERIC,
     description: 'Depth',
-  }, {
-    field: 'units',
-    type: FieldDefinition.Type.STRING,
-    optionality: FieldDefinition.Optionality.OPTIONAL,
-    description: 'Units',
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {

--- a/test/steps/scroll-to.ts
+++ b/test/steps/scroll-to.ts
@@ -44,10 +44,6 @@ describe('ScrollToPage', () => {
       const pageUrl: any = fields.filter(f => f.key === 'depth')[0];
       expect(pageUrl.optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
       expect(pageUrl.type).to.equal(FieldDefinition.Type.NUMERIC);
-
-      const units: any = fields.filter(f => f.key === 'units')[0];
-      expect(units.optionality).to.equal(FieldDefinition.Optionality.OPTIONAL);
-      expect(units.type).to.equal(FieldDefinition.Type.STRING);
     });
   });
 


### PR DESCRIPTION
Removing units from expected fields. It is still an optional field and defaults to %.