### PR TITLE
Fixed reference errors caused by rawRequest object

### DIFF
--- a/src/steps/check-network-request.ts
+++ b/src/steps/check-network-request.ts
@@ -97,7 +97,7 @@ export class CheckNetworkRequestStep extends BaseStep implements StepInterface {
   }
 
   private getPostRequestParams(request) {
-    if (request.rawRequest._headers['content-type'].includes('application/json')) {
+    if (request.rawRequest?._headers?.['content-type'].includes('application/json')) {
       return JSON.parse(request.postData);
     } else {
       return this.getUrlParams(`${request.url}?${request.postData}`);

--- a/src/steps/check-pardot-tracking.ts
+++ b/src/steps/check-pardot-tracking.ts
@@ -85,7 +85,7 @@ export class CheckPardotTrackingStep extends BaseStep implements StepInterface {
             tableRecord,
           ]);
       }
-      const record = this.createRecord(evaluatedRequests[0].rawRequest._url);
+      const record = this.createRecord(evaluatedRequests[0].url);
       return this.pass(
         'Successfully detected Pardot Tracking request for account id %d, and campaign id %d.', [aid, cid], [record]);
     } catch (e) {

--- a/src/steps/pixel-validation.ts
+++ b/src/steps/pixel-validation.ts
@@ -187,7 +187,7 @@ export class PixelValidationStep extends BaseStep implements StepInterface {
   }
 
   private getPostRequestParams(request) {
-    if (request.rawRequest._headers['content-type'].includes('application/json')) {
+    if (request.rawRequest?._headers?.['content-type'].includes('application/json')) {
       return JSON.parse(request.postData);
     } else {
       return this.getUrlParams(`${request.url}?${request.postData}`);


### PR DESCRIPTION
- Use optional chaining in the "if" block of the "getPostRequestParams" method on two steps
- In the pardot tracking step, create a record using the request.url instead of the request.rawRequest._url