### PR TITLE
GA4 pixel bug fix - Record network response with status 204

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -48,9 +48,21 @@ class ClientWrapper {
     }
 
     if (this.client.listenerCount('requestfailed') === 0) {
-      this.client.addListener('requestfailed', () => {
+      this.client.addListener('requestfailed', (request: HTTPRequest) => {
         // Used to support this.waitForNetworkIdle() method.
         this.client['__networkRequestsInflight'] = Math.max(0, this.client['__networkRequestsInflight'] - 1);
+
+        if (request.response().status() === 204) {
+          // Used to support this.getFinishedRequests() method.
+          this.client['__networkRequests'] = this.client['__networkRequests'] || [];
+          this.client['__networkRequests'].push({
+            rawRequest: request,
+            method: request.method(),
+            resourceType: request.resourceType(),
+            url: request.url(),
+            postData: request.postData(),
+          });
+        }
       });
     }
 


### PR DESCRIPTION
Records network requests that response with status 204. This will record requests sent to google analytics GA4 endpoint that responds with a status 204.