### PR TITLE
Lighthouse Bug Fix - Set User Agent to AutomatonChrome

### DIFF
--- a/src/client/mixins/lighthouse.ts
+++ b/src/client/mixins/lighthouse.ts
@@ -19,6 +19,17 @@ export class LighthouseAware {
     const config: any = throttleTo === 'mobile' ? MobileConfig : DesktopConfig;
     config.settings.onlyCategories = categories;
 
+     // Set the User-Agent based on the throttleTo value
+     if (throttleTo === 'mobile') {
+      config.settings.extraHeaders = {
+        'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1 AutomatonChrome'
+      };
+    } else {
+      config.settings.extraHeaders = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 AutomatonChrome'
+      };
+    }
+
     let { lhr } = await this.lighthouse(url, flags, config);
 
     if (lhr.runtimeError) {


### PR DESCRIPTION
Lighthouse performance checks were getting blocked by sites that block by user agent. This update will set the user agent of the browser used by Lighthouse to contain "AutomatonChrome".