### PR TITLE
Remove bulk support from Check a Cookie step

### DIFF
--- a/src/steps/cookie-check.ts
+++ b/src/steps/cookie-check.ts
@@ -14,7 +14,6 @@ export class CheckCookie extends BaseStep implements StepInterface {
     field: 'cookie',
     type: FieldDefinition.Type.STRING,
     description: 'Cookie name to check',
-    bulksupport: true,
   }, {
     field: 'operator',
     type: FieldDefinition.Type.STRING,
@@ -25,7 +24,6 @@ export class CheckCookie extends BaseStep implements StepInterface {
     type: FieldDefinition.Type.ANYSCALAR,
     optionality: FieldDefinition.Optionality.OPTIONAL,
     description: 'Expected field value',
-    bulksupport: true,
   }];
   protected expectedRecords: ExpectedRecord[] = [{
     id: 'cookies',


### PR DESCRIPTION
Removes the bulk support flag from some fields in the Check a Cookie step.