### PR TITLE
Navigate Steps - Adding option to pass the step on 404 status

### DIFF
--- a/src/steps/marketo-navigate-and-query-form.ts
+++ b/src/steps/marketo-navigate-and-query-form.ts
@@ -32,6 +32,7 @@ export class MarketoNavigateAndQueryForm extends BaseStep implements StepInterfa
     const url: string = stepData.webPageUrl;
     const throttle: boolean = stepData.throttle || false;
     const maxInflightRequests: number = stepData.maxInflightRequests || 0;
+    const passOn404: boolean = stepData.passOn404 || false;
 
     // Navigate to URL.
     try {
@@ -45,7 +46,7 @@ export class MarketoNavigateAndQueryForm extends BaseStep implements StepInterfa
       const status = await this.client.client['___lastResponse']['status']();
       console.log('>>>>> checkpoint 7: finished getting status, ending timer');
       console.timeEnd('time');
-      if (status === 404) {
+      if (status === 404 && !passOn404) {
         return this.fail('%s returned an Error: 404 Not Found', [url], [binaryRecord]);
       }
       const record = this.createRecord(url);

--- a/src/steps/navigate-and-submit-form.ts
+++ b/src/steps/navigate-and-submit-form.ts
@@ -31,6 +31,7 @@ export class NavigateAndSubmitForm extends BaseStep implements StepInterface {
     const url: string = stepData.webPageUrl;
     const throttle: boolean = stepData.throttle || false;
     const maxInflightRequests: number = stepData.maxInflightRequests || 0;
+    const passOn404: boolean = stepData.passOn404 || false;
 
     // Navigate to URL.
     try {
@@ -44,7 +45,7 @@ export class NavigateAndSubmitForm extends BaseStep implements StepInterface {
       const status = await this.client.client['___lastResponse']['status']();
       console.log('>>>>> checkpoint 7: finished getting status, ending timer');
       console.timeEnd('time');
-      if (status === 404) {
+      if (status === 404 && !passOn404) {
         return this.fail('%s returned an Error: 404 Not Found', [url], [binaryRecord]);
       }
       const record = this.createRecord(url);

--- a/src/steps/navigate-to-page.ts
+++ b/src/steps/navigate-to-page.ts
@@ -31,6 +31,7 @@ export class NavigateToPage extends BaseStep implements StepInterface {
     const url: string = stepData.webPageUrl;
     const throttle: boolean = stepData.throttle || false;
     const maxInflightRequests: number = stepData.maxInflightRequests || 0;
+    const passOn404: boolean = stepData.passOn404 || false;
 
     // Navigate to URL.
     try {
@@ -44,7 +45,7 @@ export class NavigateToPage extends BaseStep implements StepInterface {
       const status = await this.client.client['___lastResponse']['status']();
       console.log('>>>>> checkpoint 7: finished getting status, ending timer');
       console.timeEnd('time');
-      if (status === 404) {
+      if (status === 404 && !passOn404) {
         return this.fail('%s returned an Error: 404 Not Found', [url], [binaryRecord]);
       }
       const record = this.createRecord(url);


### PR DESCRIPTION
- Adds a 'passOn404' optional prop in the stepData of all Navigate steps. Toggling 'passOn404' to true will ensure that the step passes when it receive a 404 status.